### PR TITLE
Use absolute path to include test files.

### DIFF
--- a/python/cxxtest/cxxtestgen.py
+++ b/python/cxxtest/cxxtestgen.py
@@ -377,10 +377,8 @@ def isDynamic(suite):
 def writeInclude(output, file):
     '''Add #include "file" statement'''
     global lastIncluded
+    file = os.path.abspath(file)
     if file == lastIncluded: return
-    if options.outputFileName:
-        dirname = os.path.split(options.outputFileName)[0]
-        file = relpath(file, dirname)
     output.writelines( [ '#include "', file, '"\n\n' ] )
     lastIncluded = file
 


### PR DESCRIPTION
This should fix issue #55.

The downside is that if output directory is the source tree, one could previously move around the entire source tree (with the generated files) without needing to regenerate the files.
