### PR TITLE
Fix inheritance issue with GlobalFixture

### DIFF
--- a/cxxtest/GlobalFixture.h
+++ b/cxxtest/GlobalFixture.h
@@ -23,7 +23,7 @@ public:
     virtual bool tearDown();
 
     GlobalFixture();
-    ~GlobalFixture();
+    virtual ~GlobalFixture();
 
     static GlobalFixture *firstGlobalFixture();
     static GlobalFixture *lastGlobalFixture();


### PR DESCRIPTION
GlobalFixture's destructor was not marked as virtual so inheriting from
it would didn't correctly cleanup the Inherited GlobalFixture

If you had a overloaded destructer in an inherited GlobalFixture either the base destructer would get called or the overloaded destructer, which caused resource leaks.  Adding the virtual to the destructer took care of this issue.
