### PR TITLE
Tweaks to allow ErrorFormatter to show worldname

### DIFF
--- a/cxxtest/ErrorFormatter.h
+++ b/cxxtest/ErrorFormatter.h
@@ -60,7 +60,7 @@ public:
     }
 
     void enterWorld(const WorldDescription & /*desc*/) {
-        (*_o) << "Running " << totalTests;
+        (*_o) << "Running [" << CxxTest::RealWorldDescription::_worldName << "] " << totalTests;
         _o->flush();
         _dotting = true;
         _reported = false;

--- a/python/cxxtest/cxxtestgen.py
+++ b/python/cxxtest/cxxtestgen.py
@@ -331,9 +331,9 @@ def writeMain( output ):
     if options.xunit_printer:
        output.write( '    std::ofstream ofstr("%s");\n' % options.xunit_file )
        output.write( '    %s tmp(ofstr);\n' % tester_t )
-       output.write( '    CxxTest::RealWorldDescription::_worldName = "%s";\n' % options.world )
     else:
        output.write( '    %s tmp;\n' % tester_t )
+    output.write( '    CxxTest::RealWorldDescription::_worldName = "%s";\n' % options.world )
     output.write( '    status = CxxTest::Main< %s >( tmp, argc, argv );\n' % tester_t )
     output.write( '    return status;\n')
     output.write( '}\n' )


### PR DESCRIPTION
changed where worldname was set in main
added worldname to ErrorFormatter running output line

This was a patch we did so that we could run a series of test suites from scons and see 

Running [test_area_2] 21 tests.....................OK!
Running [test_area_1] 85 tests.....................................................................................OK!
