### PR TITLE
Issue #83 Solved: Regression because of 4b8f9430fd8d3f3de725dbf52468dc56ded115b3

### DIFF
--- a/cxxtest/TestSuite.h
+++ b/cxxtest/TestSuite.h
@@ -70,7 +70,11 @@ struct equals<const char*, const char*>
 {
     static bool test(const char *x, const  char *y)
     {
-        return (std::strcmp(x,y) == 0);
+      if ((x != 0) && (y != 0)) {
+         return (std::strcmp(x,y) == 0);
+      } else {
+	 return (x == y);
+      }
     }
 };
 
@@ -79,7 +83,11 @@ struct equals<char*, char*>
 {
     static bool test(char *x, char *y)
     {
-        return (std::strcmp(x,y) == 0);
+      if ((x != 0) && (y != 0)) {
+         return (std::strcmp(x,y) == 0);
+      } else {
+	 return (x == y);
+      }
     }
 };
 
@@ -88,7 +96,11 @@ struct equals<const char*, char*>
 {
     static bool test(const char *x, char *y)
     {
-        return (std::strcmp(x,y) == 0);
+       if ((x != 0) && (y != 0)) {
+          return (std::strcmp(x,y) == 0);
+       } else {
+	  return (x == y);
+       }
     }
 };
 
@@ -97,7 +109,11 @@ struct equals<char*, const char*>
 {
     static bool test(char *x, const char *y)
     {
-        return (std::strcmp(x,y) == 0);
+      if ((x != 0) && (y != 0)) {
+         return (std::strcmp(x,y) == 0);
+      } else {
+	 return (x == y);
+      }
     }
 };
 


### PR DESCRIPTION
Hello,

Sorry, my latest patch ("Support for comparison of C strings (char *) added.") has generated a regression. I have added a test to check if at least one of the pointers is NULL,
if yes, check if their values (their address not the content pointed to) are equals.

So now, theses lines work as expected:
char *foo = 0;
TS_ASSERT_EQUALS(foo,(char *)0);

Regards,

Olivier
