### PR TITLE
Fixed #89 (tearDown() not called when exception is thrown and abortTestO...

### DIFF
--- a/cxxtest/TestSuite.h
+++ b/cxxtest/TestSuite.h
@@ -330,14 +330,14 @@ void doAssertSameFiles(const char* file, int line,
 #       define _TS_CATCH_ABORT(b) _TS_CATCH_TYPE( (const CxxTest::AbortTest &), b )
 #       define _TS_CATCH_SKIPPED(b) _TS_CATCH_TYPE( (const CxxTest::SkipTest &), b )
 #       define _TS_LAST_CATCH(b) _TS_CATCH_TYPE( (...), b )
-#       define _TSM_LAST_CATCH(f,l,m) _TS_LAST_CATCH( { (CxxTest::tracker()).failedTest(f,l,m); TS_ABORT(); } )
+#       define _TSM_LAST_CATCH(f,l,m) _TS_LAST_CATCH( { (CxxTest::tracker()).failedTest(f,l,m); } )
 #       ifdef _CXXTEST_HAVE_STD
 #           define _TS_CATCH_STD(e,b) _TS_CATCH_TYPE( (const std::exception& e), b )
 #       else // !_CXXTEST_HAVE_STD
 #           define _TS_CATCH_STD(e,b)
 #       endif // _CXXTEST_HAVE_STD
 #       define ___TSM_CATCH(f,l,m) \
-            _TS_CATCH_STD(e, { (CxxTest::tracker()).failedTest(f,l,e.what()); TS_ABORT(); }) \
+            _TS_CATCH_STD(e, { (CxxTest::tracker()).failedTest(f,l,e.what()); }) \
             _TSM_LAST_CATCH(f,l,m)
 #       define __TSM_CATCH(f,l,m) \
                 _TS_CATCH_ABORT( { throw; } ) \


### PR DESCRIPTION
Fixed by restricting the effect of TS_ABORT to TS_XXX macros. TS_ABORT should not be called on an upper level because this causes the following negative effects:
- the entire test stops (world)
- tearDown() are not called neither for test cases nor for test suites which may result in resource leaks
