### PR TITLE
Building example using CMake issue.

### DIFF
--- a/build_tools/cmake/CxxTest.cmake
+++ b/build_tools/cmake/CxxTest.cmake
@@ -2,7 +2,8 @@
 include("${CMAKE_CURRENT_LIST_DIR}/FindCxxTest.cmake")
 
 function(cxx_test target source)
-    string(REGEX REPLACE "hpp$" "cpp" CPP_FILE_NAME ${source})
+    get_filename_component(CPP_FILE_NAME ${source} NAME)
+    string(REGEX REPLACE "h$|hpp$" "cpp" CPP_FILE_NAME ${CPP_FILE_NAME})
     message(${CPP_FILE_NAME})
     set(CPP_FULL_NAME "${CMAKE_CURRENT_BINARY_DIR}/${CPP_FILE_NAME}")
     add_custom_command(


### PR DESCRIPTION
Reproduction case.

Project:

<pre>
gluttton@tiptop:~/Projects/cxxexample$ ls -l
total 12
-rw-r--r--  1 gluttton gluttton  413 Nov 27 20:10 CMakeLists.txt
drwxr-xr-x 11 gluttton gluttton 4096 Nov 27 20:10 cxxtest
-rw-r--r--  1 gluttton gluttton  215 Nov 27 20:10 MyTestSuite1.h
</pre>

<pre>
gluttton@tiptop:~/Projects/cxxexample$ cat MyTestSuite1.h 
// MyTestSuite1.h
#include <cxxtest/TestSuite.h>

class MyTestSuite1 : public CxxTest::TestSuite
{
public:
    void testAddition(void)
    {
        TS_ASSERT(1 + 1 > 1);
        TS_ASSERT_EQUALS(1 + 1, 2);
    }
};
</pre>

<pre>gluttton@tiptop:~/Projects/cxxexample$ cat CMakeLists.txt 
CMAKE_MINIMUM_REQUIRED  (VERSION 2.8)
PROJECT                 (MyTestSuite1)

SET (
    CMAKE_MODULE_PATH
    ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cxxtest/build_tools/cmake"
)

FIND_PACKAGE            (PythonInterp REQUIRED)
FIND_PACKAGE            (CxxTest      REQUIRED)


INCLUDE_DIRECTORIES (
    ${PROJECT_SOURCE_DIR}/cxxtest
)


CXX_TEST (
    MyTestSuite1
    ${PROJECT_SOURCE_DIR}/MyTestSuite1.h
)
</pre>


Before:

<pre>
gluttton@tiptop:~/Projects$ mkdir cxxexamplebuild
gluttton@tiptop:~/Projects$ cd cxxexamplebuild/
gluttton@tiptop:~/Projects/cxxexamplebuild$ cmake ../cxxexample
-- The C compiler identification is GNU 4.8.1
-- The CXX compiler identification is GNU 4.8.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Found PythonInterp: /usr/bin/python (found version "2.7.5") 
/home/gluttton/Projects/cxxexample/MyTestSuite1.h
-- Configuring done
CMake Error: CMake can not determine linker language for target:MyTestSuite1
CMake Error: Cannot determine link language for target "MyTestSuite1".
-- Generating done
-- Build files have been written to: /home/gluttton/Projects/cxxexamplebuild
gluttton@tiptop:~/Projects/cxxexamplebuild$ make
[100%] Generating home/gluttton/Projects/cxxexample/MyTestSuite1.h
Traceback (most recent call last):
  File "/home/gluttton/Projects/cxxexample/cxxtest/bin/cxxtestgen", line 17, in <module>
    cxxtest.main(sys.argv)
  File "/home/gluttton/Projects/cxxexample/cxxtest/python/cxxtest/cxxtestgen.py", line 70, in main
    writeOutput()
  File "/home/gluttton/Projects/cxxexample/cxxtest/python/cxxtest/cxxtestgen.py", line 242, in writeOutput
    writeSimpleOutput()
  File "/home/gluttton/Projects/cxxexample/cxxtest/python/cxxtest/cxxtestgen.py", line 246, in writeSimpleOutput
    output = startOutputFile()
  File "/home/gluttton/Projects/cxxexample/cxxtest/python/cxxtest/cxxtestgen.py", line 285, in startOutputFile
    output = open( options.outputFileName, 'w' )
IOError: [Errno 2] No such file or directory: '/home/gluttton/Projects/cxxexamplebuild//home/gluttton/Projects/cxxexample/MyTestSuite1.h'
make[2]: *** [home/gluttton/Projects/cxxexample/MyTestSuite1.h] Error 1
make[1]: *** [CMakeFiles/MyTestSuite1.dir/all] Error 2
make: *** [all] Error 2
</pre>


After:

<pre>
gluttton@tiptop:~/Projects$ mkdir cxxexamplebuild
gluttton@tiptop:~/Projects$ cd cxxexamplebuild/
gluttton@tiptop:~/Projects/cxxexamplebuild$ cmake ../cxxexample
-- The C compiler identification is GNU 4.8.1
-- The CXX compiler identification is GNU 4.8.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Found PythonInterp: /usr/bin/python (found version "2.7.5") 
MyTestSuite1.cpp
-- Configuring done
-- Generating done
-- Build files have been written to: /home/gluttton/Projects/cxxexamplebuild
gluttton@tiptop:~/Projects/cxxexamplebuild$ make
[ 50%] Generating MyTestSuite1.cpp
Scanning dependencies of target MyTestSuite1
[100%] Building CXX object CMakeFiles/MyTestSuite1.dir/MyTestSuite1.cpp.o
Linking CXX executable MyTestSuite1
[100%] Built target MyTestSuite1
gluttton@tiptop:~/Projects/cxxexamplebuild$ ./MyTestSuite1 
Running cxxtest tests (1 test).OK!
</pre>
