### PR TITLE
fixed bug with "None" appearing in $CXXTEST_CPPPATH

### DIFF
--- a/build_tools/SCons/cxxtest.py
+++ b/build_tools/SCons/cxxtest.py
@@ -214,9 +214,11 @@ def findCxxTestHeaders(env):
     alt_path = os_cxxtestgen[:-cxxtestgen_pathlen]
 
     searchpaths = [default_path, alt_path]
+    foundpaths = []
     for p in searchpaths:
         if os.path.exists(os.path.join(p, 'cxxtest', searchfile)):
-            return p
+            foundpaths.append(p)
+    return foundpaths
 
 def generate(env, **kwargs):
     """
@@ -286,7 +288,7 @@ def generate(env, **kwargs):
         env["CXXTEST"] = findCxxTestGen(env)
 
     # find and add the CxxTest headers to the path.
-    env.AppendUnique( CXXTEST_CPPPATH = [findCxxTestHeaders(env)]  )
+    env.AppendUnique( CXXTEST_CPPPATH = findCxxTestHeaders(env)  )
     
     cxxtest = env['CXXTEST']
     if cxxtest:


### PR DESCRIPTION
I have a project where I use variant dirs and '*.t.h' files are spreaded among subdirectories. I use cxxtest installed via apt-get. When my sources are compiled with CxxTest, I see include paths such as `-Ifoo/bar/None` (note the `None`). I've printed the default value of `CXXTEST_CPPPATH` in my SConsript and it looks like `['#', None]`.  To reproduce this, we need a situation when `findCxxTestHeaders()` finds nothing (so it returns None).

This patch is an approach to fix this issue. The issue is actually harmless (the code compiles) but the generated commandline is unnecessarily cluttered with "None" paths.
