### PR TITLE
Allow GUIs to actually parse command line arguments again.

### DIFF
--- a/cxxtest/Gui.h
+++ b/cxxtest/Gui.h
@@ -27,14 +27,14 @@ public:
     GuiListener() : _state(GREEN_BAR) {}
     virtual ~GuiListener() {}
 
-    virtual void runGui(int &argc, char **argv, TestListener &listener)
+    virtual void runGui(TestListener &listener)
     {
-        enterGui(argc, argv);
+        enterGui();
         TestRunner::runAllTests(listener);
         leaveGui();
     }
 
-    virtual void enterGui(int & /*argc*/, char ** /*argv*/) {}
+    virtual void enterGui() {}
     virtual void leaveGui() {}
 
     //
@@ -171,25 +171,30 @@ private:
 template<class GuiT, class TuiT>
 class GuiTuiRunner : public TeeListener
 {
-    int* _argc;
-    char **_argv;
     GuiT _gui;
     TuiT _tui;
 
 public:
-    GuiTuiRunner() : _argc(0), _argv(0) {}
+    GuiTuiRunner() {}
 
-    void process_commandline(int& argc, char** argv)
+    bool process_commandline_args(int& i, int& argc, char* argv[])
     {
-        _argc = &argc;
-        _argv = argv;
-        setFirst(_gui);
-        setSecond(_tui);
+        if (i == 0) // Init
+        {
+            setFirst(_gui);
+            setSecond(_tui);
+        }
+        return _gui.process_commandline_args(i, argc, argv);
+    }
+
+    void print_help(const char* name)
+    {
+        _gui.print_help(name);
     }
 
     int run()
     {
-        _gui.runGui(*_argc, _argv, *this);
+        _gui.runGui(*this);
         return tracker().failedTests();
     }
 };

--- a/cxxtest/QtGui.h
+++ b/cxxtest/QtGui.h
@@ -41,12 +41,6 @@ namespace CxxTest
 class QtGui : public GuiListener
 {
 public:
-    void enterGui(int &argc, char **argv)
-    {
-        parseCommandLine(argc, argv);
-        createApplication(argc, argv);
-    }
-
     void enterWorld(const WorldDescription &wd)
     {
         createWindow(wd);
@@ -100,6 +94,42 @@ public:
         }
     }
 
+    virtual bool process_commandline_args(int& i, int& argc, char* argv[])
+    {
+        if (i == 0)
+        {
+            _startMinimized = _keep = false;
+            _title = argv[0];
+            // Removes arguments it recognizes
+            _application = new QApplication(argc, argv);
+            return true;
+        }
+
+        if (!strcmp(argv[i], "-minimized"))
+        {
+            _startMinimized = true;
+        }
+        else if (!strcmp(argv[i], "-keep"))
+        {
+            _keep = true;
+        }
+        else if (!strcmp(argv[i], "-title"))
+        {
+            if (++i >= argc)
+            {
+                return false;
+            }
+
+            _title = argv[i];
+        }
+        else
+        {
+            return false;
+        }
+
+        return true;
+    }
+
 private:
     QString _title;
     bool _startMinimized, _keep;
@@ -111,34 +141,6 @@ private:
     QProgressBar *_progressBar;
     QStatusBar *_statusBar;
     QLabel *_suiteName, *_testName, *_testsDone;
-
-    void parseCommandLine(int argc, char **argv)
-    {
-        _startMinimized = _keep = false;
-        _title = argv[0];
-
-        for (int i = 1; i < argc; ++ i)
-        {
-            QString arg(argv[i]);
-            if (arg == "-minimized")
-            {
-                _startMinimized = true;
-            }
-            else if (arg == "-keep")
-            {
-                _keep = true;
-            }
-            else if (arg == "-title" && (i + 1 < argc))
-            {
-                _title = argv[++i];
-            }
-        }
-    }
-
-    void createApplication(int &argc, char **argv)
-    {
-        _application = new QApplication(argc, argv);
-    }
 
     void createWindow(const WorldDescription &wd)
     {

--- a/cxxtest/TestListener.h
+++ b/cxxtest/TestListener.h
@@ -30,7 +30,8 @@ class TestListener
 public:
     TestListener() {}
     virtual ~TestListener() {}
-    virtual void process_commandline(int& /*argc*/, char** /*argv*/) {}
+    virtual void print_help(const char* /*name*/) {}
+    virtual bool process_commandline_args(int& /*i*/, int& /*argc*/, char* /*argv*/[]) { return false; }
 
     virtual void enterWorld(const WorldDescription & /*desc*/) {}
     virtual void enterSuite(const SuiteDescription & /*desc*/) {}

--- a/cxxtest/Win32Gui.h
+++ b/cxxtest/Win32Gui.h
@@ -38,11 +38,6 @@ namespace CxxTest
 class Win32Gui : public GuiListener
 {
 public:
-    void enterGui(int &argc, char **argv)
-    {
-        parseCommandLine(argc, argv);
-    }
-
     void enterWorld(const WorldDescription &wd)
     {
         getTotalTests(wd);
@@ -94,6 +89,40 @@ public:
         DestroyWindow(_mainWindow);
     }
 
+    virtual bool process_commandline_args(int& i, int& argc, char* argv[])
+    {
+        if (i == 0)
+        {
+            _startMinimized = _keep = false;
+            _title = argv[0];
+            return true;
+        }
+
+        if (!lstrcmpA(argv[i], "-minimized"))
+        {
+            _startMinimized = true;
+        }
+        else if (!lstrcmpA(argv[i], "-keep"))
+        {
+            _keep = false;
+        }
+        else if (!lstrcmpA(argv[i], "-title"))
+        {
+            if (++i >= argc)
+            {
+                return false;
+            }
+
+            _title = argv[i];
+        }
+        else
+        {
+            return false;
+        }
+
+        return true;
+    }
+
 private:
     const char *_title;
     bool _startMinimized, _keep;
@@ -116,28 +145,6 @@ private:
     char _statusTestsDone[sizeof("1000000000 of  (100%)") + WorldDescription::MAX_STRLEN_TOTAL_TESTS];
     DWORD _worldStart, _suiteStart, _testStart;
     char _timeString[sizeof("00:00:00")];
-
-    void parseCommandLine(int argc, char **argv)
-    {
-        _startMinimized = _keep = false;
-        _title = argv[0];
-
-        for (int i = 1; i < argc; ++ i)
-        {
-            if (!lstrcmpA(argv[i], "-minimized"))
-            {
-                _startMinimized = true;
-            }
-            else if (!lstrcmpA(argv[i], "-keep"))
-            {
-                _keep = true;
-            }
-            else if (!lstrcmpA(argv[i], "-title") && (i + 1 < argc))
-            {
-                _title = argv[++i];
-            }
-        }
-    }
 
     void getTotalTests()
     {

--- a/cxxtest/X11Gui.h
+++ b/cxxtest/X11Gui.h
@@ -36,11 +36,6 @@ namespace CxxTest
 class X11Gui : public GuiListener
 {
 public:
-    void enterGui(int &argc, char **argv)
-    {
-        parseCommandLine(argc, argv);
-    }
-
     void enterWorld(const WorldDescription &wd)
     {
         openDisplay();
@@ -98,6 +93,108 @@ public:
         }
     }
 
+#if defined(_CXXTEST_HAVE_STD)
+    virtual void print_help(const char* name)
+    {
+        CXXTEST_STD(cerr) << name << " -title <title>              Set the window caption\n";
+        CXXTEST_STD(cerr) << name << " -fn <font>                  Set the font\n";
+        CXXTEST_STD(cerr) << name << " -font <font>}\n";
+        CXXTEST_STD(cerr) << name << " -bg <color>                 Set the background color (default=Grey)\n";
+        CXXTEST_STD(cerr) << name << " -background <color>\n";
+        CXXTEST_STD(cerr) << name << " -fg <color>                 Set the text color (default=Black)\n";
+        CXXTEST_STD(cerr) << name << " -foreground <color>\n";
+        CXXTEST_STD(cerr) << name << " -green/-yellow/-red <color> Set the colors of the bar" << CXXTEST_STD(endl);
+    }
+#endif
+
+    virtual bool process_commandline_args(int& i, int& argc, char* argv[])
+    {
+        if (i == 0)
+        {
+            _programName = argv[0];
+
+            _fontName = 0;
+            _foregroundName = "Black";
+            _backgroundName = "Grey";
+            _greenName = "Green";
+            _yellowName = "Yellow";
+            _redName = "Red";
+            return true;
+        }
+
+        if (!strcmp(argv[i], "-title"))
+        {
+            if (++i >= argc)
+            {
+                return false;
+            }
+
+            _programName = argv[i];
+            return true;
+        }
+        else if (!strcmp(argv[i], "-fn") || !strcmp(argv[i], "-font"))
+        {
+            if (++i >= argc)
+            {
+                return false;
+            }
+
+            _fontName = argv[i];
+            return true;
+        }
+        else if (!strcmp(argv[i], "-fg") || !strcmp(argv[i], "-foreground"))
+        {
+            if (++i >= argc)
+            {
+                return false;
+            }
+
+            _foregroundName = argv[i];
+            return true;
+        }
+        else if (!strcmp(argv[i], "-bg") || !strcmp(argv[i], "-background"))
+        {
+            if (++i >= argc)
+            {
+                return false;
+            }
+
+            _backgroundName = argv[i];
+            return true;
+        }
+        else if (!strcmp(argv[i], "-green"))
+        {
+            if (++i >= argc)
+            {
+                return false;
+            }
+
+            _greenName = argv[i];
+            return true;
+        }
+        else if (!strcmp(argv[i], "-yellow"))
+        {
+            if (++i >= argc)
+            {
+                return false;
+            }
+
+            _yellowName = argv[i];
+            return true;
+        }
+        else if (!strcmp(argv[i], "-red"))
+        {
+            if (++i >= argc)
+            {
+                return false;
+            }
+
+            _redName = argv[i];
+            return true;
+        }
+        return false;
+    }
+
 private:
     const char *_programName;
     Display *_display;
@@ -115,50 +212,6 @@ private:
     int _textHeight, _textDescent;
     long _eventMask;
     Colormap _colormap;
-
-    void parseCommandLine(int &argc, char **argv)
-    {
-        _programName = argv[0];
-
-        _fontName = 0;
-        _foregroundName = "Black";
-        _backgroundName = "Grey";
-        _greenName = "Green";
-        _yellowName = "Yellow";
-        _redName = "Red";
-
-        for (int i = 1; i + 1 < argc; ++ i)
-        {
-            if (!strcmp(argv[i], "-title"))
-            {
-                _programName = argv[++ i];
-            }
-            else if (!strcmp(argv[i], "-fn") || !strcmp(argv[i], "-font"))
-            {
-                _fontName = argv[++ i];
-            }
-            else if (!strcmp(argv[i], "-fg") || !strcmp(argv[i], "-foreground"))
-            {
-                _foregroundName = argv[++ i];
-            }
-            else if (!strcmp(argv[i], "-bg") || !strcmp(argv[i], "-background"))
-            {
-                _backgroundName = argv[++ i];
-            }
-            else if (!strcmp(argv[i], "-green"))
-            {
-                _greenName = argv[++ i];
-            }
-            else if (!strcmp(argv[i], "-yellow"))
-            {
-                _yellowName = argv[++ i];
-            }
-            else if (!strcmp(argv[i], "-red"))
-            {
-                _redName = argv[++ i];
-            }
-        }
-    }
 
     void openDisplay()
     {


### PR DESCRIPTION
GUIs can now parse command line arguments that start with an option starting with '-' again.
They can handle any number of arguments after that.
GUIs can now print their own specific help.
Win32Gui and QtGui not tested. (I'll see if I can update QtGui for Qt 4 or 5, if there is interest)

Previously the command line parsing code aborted on any option starting with '-', now it can ask the GUI to handle that option (and further parameters).

(Written as a upgrade to 4.3 (from 3.x) broke our command line parameters and I started to fix that bug as a part of it (See http://trac.wildfiregames.com/ticket/2488 ))
