### PR TITLE
Modify preprocessor : WIN32

### DIFF
--- a/cxxtest/XmlFormatter.h
+++ b/cxxtest/XmlFormatter.h
@@ -599,7 +599,7 @@ private:
         const time_t now(time(NULL));
         char current_date_string[27];
         
-#ifdef WIN32
+#ifdef _WIN32
         if (ctime_s(current_date_string, sizeof(current_date_string)-1, &now) == 0)
         {
             retVal = current_date_string;


### PR DESCRIPTION
WIN32 is defined by the SDK or the build environment, so it does not use
the implementation reserved namespace
_WIN32 is defined by the compiler so it uses the underscore to place it
in the implementation-reserved namespace
