### PR TITLE
Adjusting XML output to let Jenkins' xunit parse the XML files correctly

### DIFF
--- a/cxxtest/XmlFormatter.h
+++ b/cxxtest/XmlFormatter.h
@@ -150,13 +150,14 @@ public:
         os << "        <" << name.c_str() << " ";
         std::map<std::string, std::string>::iterator curr = attribute.begin();
         std::map<std::string, std::string>::iterator end = attribute.end();
-        bool processedValue = false;
         while (curr != end)
         {
+//            os << curr->first.c_str()
+//               << "=\"" << curr->second.c_str() << "\" ";
+//            curr++;
             if (curr->first.compare("type")) {
                 os << curr->first.c_str()
                    << "=\"" << escape(value.str()).c_str() << "\" ";
-                processedValue = true;
             }
             else {
                 os << curr->first.c_str()
@@ -166,12 +167,10 @@ public:
 
         }
         os << ">";
-        if (!processedValue) {
-            if (!value.str().empty())
-            {
-                os << escape(value.str()).c_str()
-            }
-        }
+//        if (!value.str().empty())
+//        {
+//            os << escape(value.str()).c_str()
+//        }
         os << "</" << name.c_str() << ">";
         os.endl(os);
     }
@@ -251,6 +250,7 @@ public:
         o << "    </testcase>";
         o.endl(o);
     }
+
 };
 
 class XmlFormatter : public TestListener

--- a/cxxtest/XmlFormatter.h
+++ b/cxxtest/XmlFormatter.h
@@ -156,6 +156,7 @@ public:
             if (curr->first.compare("type")) {
                 os << curr->first.c_str()
                    << "=\"" << escape(value.str()).c_str() << "\" ";
+                processedValue = true;
             }
             else {
                 os << curr->first.c_str()


### PR DESCRIPTION
I tried to use CxxTest 4.4 with our Jenkins and xunit but could not make it work out of the box with the JUnit parsing configuration. After checking the JUnit XSD specification, I adjusted the output from XmlFormatter so that our Jenkins is able to parse the CxxTest output.
