### PR TITLE
fix bin/cxxtest.bat - prevent it from invoking itself

### DIFF
--- a/bin/cxxtestgen.bat
+++ b/bin/cxxtestgen.bat
@@ -1,3 +1,8 @@
 @echo off
-rem Just run the python script
-python %0 %*
+setlocal
+
+rem Strip .bat extension, if present
+set me=%0
+if "%me:~-4,4%" == ".bat" (set py=%me:~0,-4%) else (set py=%me%)
+rem Run the python script
+python %py% %*


### PR DESCRIPTION
If you run ``bin\cxxtestgen.bat`` (with the ``.bat`` extension), then the script tries to pass itself to python  interpreter.  It happens, under certain circumstances, when using SCons cxxtest tool, for example. This PR fixes this.