### PR TITLE
Add includes

### DIFF
--- a/cxxtest/Descriptions.cpp
+++ b/cxxtest/Descriptions.cpp
@@ -13,6 +13,7 @@
 #define __cxxtest__Descriptions_cpp__
 
 #include <cxxtest/Descriptions.h>
+#include <cxxtest/ValueTraits.h>
 
 namespace CxxTest
 {

--- a/cxxtest/LinkedList.cpp
+++ b/cxxtest/LinkedList.cpp
@@ -13,6 +13,8 @@
 #define __cxxtest__LinkedList_cpp__
 
 #include <cxxtest/LinkedList.h>
+#include <cxxtest/GlobalFixture.h>
+#include <cxxtest/RealDescriptions.h>
 
 namespace CxxTest
 {

--- a/python/python3/cxxtest/cxxtest_parser.py
+++ b/python/python3/cxxtest/cxxtest_parser.py
@@ -12,7 +12,7 @@
 import codecs
 import re
 import sys
-from cxxtest.cxxtest_misc import abort
+from cxxtest_misc import abort
 
 # Global variables
 suites = []
@@ -36,7 +36,7 @@ def scanInputFiles(files, _options):
     #
     for file in files:
         scanInputFile(file)
-    if len(suites) is 0 and not options.root:
+    if len(suites) == 0 and not options.root:
         abort( 'No tests defined' )
     return [options,suites]
 
@@ -233,7 +233,7 @@ def closeSuite():
     '''Close current suite and add it to the list if valid'''
     global suite
     if suite is not None:
-        if len(suite['tests']) is not 0:
+        if len(suite['tests']) != 0:
             verifySuite(suite)
             rememberSuite(suite)
         suite = None

--- a/python/python3/cxxtest/cxxtestgen.py
+++ b/python/python3/cxxtest/cxxtestgen.py
@@ -15,27 +15,27 @@
 
 __all__ = ['main', 'create_manpage']
 
-from . import __release__
+import __release__
 import os
 import sys
 import re
 import glob
 from optparse import OptionParser
-from . import cxxtest_parser
+import cxxtest_parser
 from string import Template
 
 try:
-    from . import cxxtest_fog
+    import cxxtest_fog
     imported_fog=True
 except ImportError:
     imported_fog=False
 
-from .cxxtest_misc import abort
+from cxxtest_misc import abort
 
 try:
     from os.path import relpath
 except ImportError:
-    from .cxxtest_misc import relpath
+    from cxxtest_misc import relpath
 
 # Global data is initialized by main()
 options = []
@@ -627,4 +627,4 @@ def create_manpage():
     OUTPUT.write( man_template.substitute(usage=usage, description=description, options=options) )
     OUTPUT.close()
 
-
+main()


### PR DESCRIPTION
I had to add some header files to get my project to build in MSVS 2019.

These source files referenced symbols from headers that were not included in the source:
- Descriptions.cpp referenced numberToString() from ValueTraits.h
- LinkedList.cpp referenced GlobalFixture::_list from GlobalFixture.h
- LinkedList.cpp referenced RealSuiteDescription::_suites from RealDescriptions.h

This pull request aims to include those header files.