### PR TITLE
Add includes

### DIFF
--- a/cxxtest/Descriptions.cpp
+++ b/cxxtest/Descriptions.cpp
@@ -13,6 +13,7 @@
 #define __cxxtest__Descriptions_cpp__
 
 #include <cxxtest/Descriptions.h>
+#include <cxxtest/ValueTraits.h>
 
 namespace CxxTest
 {

--- a/cxxtest/LinkedList.cpp
+++ b/cxxtest/LinkedList.cpp
@@ -13,6 +13,8 @@
 #define __cxxtest__LinkedList_cpp__
 
 #include <cxxtest/LinkedList.h>
+#include <cxxtest/GlobalFixture.h>
+#include <cxxtest/RealDescriptions.h>
 
 namespace CxxTest
 {


### PR DESCRIPTION
I had to add some header files to get my project to build in MSVS 2019.

These source files referenced symbols from headers that were not included in the source:
- Descriptions.cpp referenced numberToString() from ValueTraits.h
- LinkedList.cpp referenced GlobalFixture::_list from GlobalFixture.h
- LinkedList.cpp referenced RealSuiteDescription::_suites from RealDescriptions.h

This pull request aims to include those header files.