### PR TITLE
Fix GCC warnings for samples

### DIFF
--- a/cxxtest/ValueTraits.cpp
+++ b/cxxtest/ValueTraits.cpp
@@ -126,8 +126,9 @@ char *bytesToString(const unsigned char *bytes, unsigned numBytes, unsigned maxB
 #ifndef CXXTEST_USER_VALUE_TRAITS
 unsigned ValueTraits<const double>::requiredDigitsOnLeft(double t)
 {
+    int base = BASE;
     unsigned digits = 1;
-    for (t = (t < 0.0) ? -t : t; t > 1.0; t /= BASE)
+    for (t = (t < 0.0) ? -t : t; t > 1.0; t /= base)
     {
         ++ digits;
     }
@@ -157,12 +158,13 @@ void ValueTraits<const double>::hugeNumber(double t)
 
 void ValueTraits<const double>::normalNumber(double t)
 {
+    int base = BASE;
     char *s = doNegative(t);
     s = doubleToString(t, s);
     s = copyString(s, ".");
     for (unsigned i = 0; i < DIGITS_ON_RIGHT; ++ i)
     {
-        s = numberToString((unsigned)(t *= BASE) % BASE, s);
+        s = numberToString((unsigned)(t *= base) % base, s);
     }
 }
 

--- a/cxxtest/ValueTraits.h
+++ b/cxxtest/ValueTraits.h
@@ -37,6 +37,15 @@
 
 namespace CxxTest
 {
+    /// remove_const
+    template<typename T>
+    struct remove_const
+    { typedef T type; };
+
+    template<typename T>
+    struct remove_const<T const>
+    { typedef T type; };
+
 //
 // This is how we use the value traits
 //
@@ -117,7 +126,7 @@ inline ValueTraits<T> traits(T t)
     { \
         ValueTraits< CXXTEST_OLD_CLASS > _old; \
     public: \
-        ValueTraits( CXXTEST_NEW_CLASS n ) : _old( (CXXTEST_OLD_CLASS)n ) {} \
+        ValueTraits( CXXTEST_NEW_CLASS n ) : _old( static_cast<remove_const<CXXTEST_OLD_CLASS>::type>(n) ) {} \
         const char *asString( void ) const { return _old.asString(); } \
     }
 


### PR DESCRIPTION
Fixes GCC build for sample/Makefile.unix as it uses flags: -Wall -W -Werror

The ValueTraits.h commit comes from changes made in scummvm:
https://github.com/scummvm/scummvm/commit/f2f64161a10b3258e5491e2c477092bdd5a4da11